### PR TITLE
Fix geometry bound

### DIFF
--- a/src/GoogleMaps/Resources/Geometry.php
+++ b/src/GoogleMaps/Resources/Geometry.php
@@ -21,9 +21,9 @@ class Geometry implements ArraySerializableInterface
 	const ROOFTOP 			 = 'rooftop';
 	
 	protected $bounds = null;
-	protected $location = null;
-	protected $locationType = null;
-	protected $viewport = null;
+	protected $location;
+	protected $locationType;
+	protected $viewport;
 	
 	public function __construct(array $data)
 	{


### PR DESCRIPTION
When trying to geocode for "222 Broadway, New York, NY" i got this:

Fatal error: Call to a member function getArrayCopy() on a non-object in .../vendor/cderue/googlemaps/src/GoogleMaps/Resources/Geometry.php on line 99

In this case Google is not sending the bounds section in the response. As in Geometry::exchangeArray you are skipping the creation of the LatLngBounds object when "bounds" is not set. I added the same check in Geometry::getArrayCopy section.
